### PR TITLE
fix: use environment vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/node-fetch": "latest",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
+    "dotenv": "^16.0.3",
     "eslint": "8.30.0",
     "eslint-plugin-qwik": "0.16.1",
     "node-fetch": "3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@auth/core': 0.2.5
-  '@builder.io/qwik': 0.16.2
+  '@builder.io/qwik': ^0.16.2
   '@builder.io/qwik-city': 0.1.0-beta9
   '@next-auth/prisma-adapter': ^1.0.5
   '@prisma/client': ^4.7.1
@@ -11,6 +11,7 @@ specifiers:
   '@types/node-fetch': latest
   '@typescript-eslint/eslint-plugin': 5.46.1
   '@typescript-eslint/parser': 5.46.1
+  dotenv: ^16.0.3
   eslint: 8.30.0
   eslint-plugin-qwik: 0.16.1
   node-fetch: 3.3.0
@@ -34,6 +35,7 @@ devDependencies:
   '@types/node-fetch': 2.6.2
   '@typescript-eslint/eslint-plugin': 5.46.1_mqzxmroayievgzgel6yrqgih5i
   '@typescript-eslint/parser': 5.46.1_lzzuuodtsqwxnvqeq4g4likcqa
+  dotenv: 16.0.3
   eslint: 8.30.0
   eslint-plugin-qwik: 0.16.1_eslint@8.30.0
   node-fetch: 3.3.0
@@ -828,6 +830,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: true
+
+  /dotenv/16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /esbuild/0.16.9:

--- a/src/lib/frameworks-qwik/handlers.ts
+++ b/src/lib/frameworks-qwik/handlers.ts
@@ -38,10 +38,10 @@ export const QwikCityAuth = (
 ): {
   onRequest: RequestHandler;
 } => {
-  const env = import.meta.env;
+  const env = process.env;
   config.prefix ??= '/api/auth';
-  config.secret ??= env.VITE_AUTH_SECRET;
-  config.trustHost ??= !!(env.AUTH_TRUST_HOST ?? env.VERCEL ?? env.DEV);
+  config.secret ??= env.AUTH_SECRET;
+  config.trustHost ??= !!(env.TRUST_HOST ?? env.VERCEL ?? import.meta.env.DEV);
 
   return {
     onRequest: (event: RequestEvent) => QwikCityAuthHandler(event, config.prefix!, config),
@@ -70,7 +70,7 @@ export const getServerSession = async (
   config: QwikCityAuthConfig = { providers: [] }
 ): Promise<Session | null> => {
   config.prefix ??= '/api/auth';
-  config.secret ??= import.meta.env.VITE_AUTH_SECRET;
+  config.secret ??= process.env.AUTH_SECRET;
   config.trustHost ??= true;
 
   const url = new URL(request.url);

--- a/src/routes/api/auth/[...authjs]/index!.ts
+++ b/src/routes/api/auth/[...authjs]/index!.ts
@@ -6,6 +6,7 @@ import { QwikCityAuth } from '~/lib/frameworks-qwik';
 
 export const { onRequest } = QwikCityAuth({
   providers: [
+    //@ts-expect-error issue https://github.com/nextauthjs/next-auth/issues/6174
     Credentials({
       name: 'Email',
       credentials: {
@@ -19,14 +20,16 @@ export const { onRequest } = QwikCityAuth({
         return null;
       },
     }),
+    //@ts-expect-error issue https://github.com/nextauthjs/next-auth/issues/6174
     Auth0({
-      clientId: import.meta.env.VITE_AUTH0_ID,
-      clientSecret: import.meta.env.VITE_AUTH0_SECRET,
-      issuer: import.meta.env.VITE_AUTH0_ISSUER,
+      clientId: process.env.AUTH0_ID || '',
+      clientSecret: process.env.AUTH0_SECRET || '',
+      issuer: process.env.AUTH0_ISSUER,
     }),
+    //@ts-expect-error issue https://github.com/nextauthjs/next-auth/issues/6174
     Github({
-      clientId: import.meta.env.VITE_GITHUB_ID,
-      clientSecret: import.meta.env.VITE_GITHUB_SECRET,
+      clientId: process.env.GITHUB_ID || '',
+      clientSecret: process.env.GITHUB_SECRET || '',
     }),
   ],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import { qwikVite } from '@builder.io/qwik/optimizer';
 import { qwikCity } from '@builder.io/qwik-city/vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 export default defineConfig(() => {
   return {


### PR DESCRIPTION
VITE_ vars can be exposed to the client, process.env vars are protected against that