### PR TITLE
fix: remove unnecessary request processing code

### DIFF
--- a/src/lib/frameworks-qwik/utils.ts
+++ b/src/lib/frameworks-qwik/utils.ts
@@ -1,18 +1,6 @@
-import { CookieOptions, RequestContext } from '@builder.io/qwik-city/middleware/request-handler';
+import { CookieOptions } from '@builder.io/qwik-city/middleware/request-handler';
 import { parseCookie, splitCookieHeader } from './cookie';
 import { ContentType } from './types';
-
-export const getBody = async (req: RequestContext): Promise<Record<string, any> | undefined> => {
-  if (req.method !== 'POST') return;
-
-  const contentType = req.headers.get('content-type');
-  if (contentType?.includes('application/json')) {
-    return await req.json();
-  } else if (contentType?.includes('application/x-www-form-urlencoded')) {
-    const params = new URLSearchParams(await req.text());
-    return params;
-  }
-};
 
 export const processResponse = async (res: Response) => {
   let redirect: URL | undefined;
@@ -42,27 +30,12 @@ export const processResponse = async (res: Response) => {
   const splitCookies = splitCookieHeader(cookieHeader);
 
   splitCookies.forEach((cookie) => {
-    const { name, value, ...options } = parseCookie(cookie);
-    const opts = options as CookieOptions;
-    cookies.push({ name, value, options: opts });
+    const { name, value, ...cookieOptions } = parseCookie(cookie);
+    const options = cookieOptions as CookieOptions;
+    cookies.push({ name, value, options });
   });
 
   content = contentType === 'json' ? await res.json() : await res.text();
 
   return { content, contentType, redirect, cookies };
-};
-
-export const requestContextToRequest = (
-  requestContext: RequestContext,
-  body?: Record<string, any>,
-  newUrl?: string
-): Request => {
-  const url = new URL((newUrl ?? requestContext.url).replace(/\/$/, ''));
-
-  return new Request(url, {
-    method: requestContext.method,
-    headers: requestContext.headers,
-    // @ts-ignore
-    body,
-  });
 };


### PR DESCRIPTION
This can be done in light of the fact that Request event now just returns a plan Request